### PR TITLE
jt-fixed raw json display on profile page

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -11,7 +11,9 @@ module.exports = {
   "addons": [
     "@storybook/addon-links",
     "@storybook/addon-essentials",
-    "@storybook/preset-create-react-app"
+    "@storybook/preset-create-react-app",
+    'storybook-addon-mock',
+
   ],
   webpackFinal: async (config) => {
     config.plugins.push(new WebpackPluginFailBuildOnWarning());

--- a/frontend/src/fixtures/currentUserFixtures.js
+++ b/frontend/src/fixtures/currentUserFixtures.js
@@ -104,7 +104,9 @@ const apiCurrentUserFixtures = {
             "locale": "en",
             "hostedDomain": null,
             "admin": false,
-            "rider": true
+            "rider": true,
+            "driver": false,
+            "wheelchair": true
         },
         "roles": [
             {

--- a/frontend/src/fixtures/currentUserFixtures.js
+++ b/frontend/src/fixtures/currentUserFixtures.js
@@ -11,7 +11,9 @@ const apiCurrentUserFixtures = {
             "emailVerified": true,
             "locale": "en",
             "hostedDomain": "ucsb.edu",
-            "admin": true
+            "admin": true,
+            "rider": false,
+            "driver": false
         },
         "roles": [
             {
@@ -59,7 +61,50 @@ const apiCurrentUserFixtures = {
             "emailVerified": true,
             "locale": "en",
             "hostedDomain": null,
-            "admin": false
+            "admin": false,
+            "driver": true
+        },
+        "roles": [
+            {
+                "authority": "SCOPE_openid"
+            },
+            {
+                "authority": "ROLE_USER",
+                "attributes": {
+                    "sub": "102656447703889917227",
+                    "name": "Phillip Conrad",
+                    "given_name": "Phillip",
+                    "family_name": "Conrad",
+                    "picture": "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
+                    "email": "pconrad.cis@gmail.com",
+                    "email_verified": true,
+                    "locale": "en"
+                }
+            },
+            {
+                "authority": "SCOPE_https://www.googleapis.com/auth/userinfo.profile"
+            },
+            {
+                "authority": "SCOPE_https://www.googleapis.com/auth/userinfo.email"
+            }
+        ]
+
+    },
+    userOnly2: {
+
+        "user": {
+            "id": 2,
+            "email": "pconrad.cis@gmail.com",
+            "googleSub": "102656447703889917227",
+            "pictureUrl": "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
+            "fullName": "Phillip Conrad",
+            "givenName": "Phillip",
+            "familyName": "Conrad",
+            "emailVerified": true,
+            "locale": "en",
+            "hostedDomain": null,
+            "admin": false,
+            "rider": true
         },
         "roles": [
             {

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -4,41 +4,51 @@ import RoleBadge from "main/components/Profile/RoleBadge";
 import { useCurrentUser } from "main/utils/currentUser";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 
-import ReactJson from "react-json-view";
 const ProfilePage = () => {
+  const { data: currentUser } = useCurrentUser();
 
-    const { data: currentUser } = useCurrentUser();
+  if (!currentUser.loggedIn) {
+    return <p>Not logged in.</p>;
+  }
 
-    if (!currentUser.loggedIn) {
-        return (
-            <p>Not logged in.</p>
-        )
-    }
+  const { email, pictureUrl, fullName } = currentUser.root.user;
+//   const emailVerified = currentUser.root.user.emailVerified;
 
-    const { email, pictureUrl, fullName } = currentUser.root.user;
-    return (
-        <BasicLayout>
-            <Row className="align-items-center profile-header mb-5 text-center text-md-left">
-                <Col md={2}>
-                    <img
-                        src={pictureUrl}
-                        alt="Profile"
-                        className="rounded-circle img-fluid profile-picture mb-3 mb-md-0"
-                    />
-                </Col>
-                <Col md>
-                    <h2>{fullName}</h2>
-                    <p className="lead text-muted">{email}</p>
-                    <RoleBadge role={"ROLE_USER"} currentUser={currentUser}/>
-                    <RoleBadge role={"ROLE_MEMBER"} currentUser={currentUser}/>
-                    <RoleBadge role={"ROLE_ADMIN"} currentUser={currentUser}/>
-                </Col>
-            </Row>
-            <Row className="text-left">
-                <ReactJson src={currentUser.root} />
-            </Row>
-        </BasicLayout>
-    );
+  return (
+    <BasicLayout>
+      <Row className="align-items-center profile-header mb-5 text-center text-md-left">
+        <Col md={2}>
+          <img
+            src={pictureUrl}
+            alt="Profile"
+            className="rounded-circle img-fluid profile-picture mb-3 mb-md-0"
+          />
+        </Col>
+        <Col md>
+          <h2>{fullName}</h2>
+          <p className="lead text-muted">{email}</p>
+          <RoleBadge role={"ROLE_USER"} currentUser={currentUser} />
+          <RoleBadge role={"ROLE_MEMBER"} currentUser={currentUser} />
+          <RoleBadge role={"ROLE_ADMIN"} currentUser={currentUser} />
+          <RoleBadge role={"ROLE_DRIVER"} currentUser={currentUser} />
+          <RoleBadge role={"ROLE_RIDER"} currentUser={currentUser} />
+        </Col>
+      </Row>
+      <Row className="text-left">
+        <div>
+            <h4>Pronouns:</h4>
+            <p>{currentUser.root.user.pronouns}</p>
+            <h4>Email Verified?</h4>
+            <p>{currentUser.root.user.emailVerified ? "Yes" : "No"}</p>
+            <h4>Email</h4>
+            <p>{email}</p>
+        </div>
+      </Row>
+    </BasicLayout>
+  );
 };
 
 export default ProfilePage;
+
+
+

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -4,15 +4,16 @@ import RoleBadge from "main/components/Profile/RoleBadge";
 import { useCurrentUser } from "main/utils/currentUser";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 
-const ProfilePage = () => {
-  const { data: currentUser } = useCurrentUser();
+const ProfilePage = ({user}) => {
+  const { data: currentUserFromHook } = useCurrentUser();
 
+  const currentUser = (user || currentUserFromHook)
+  console.log("currentUser: ", currentUser);
   if (!currentUser.loggedIn) {
     return <p>Not logged in.</p>;
   }
 
   const { email, pictureUrl, fullName } = currentUser.root.user;
-
 
   return (
     <BasicLayout>

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -8,7 +8,6 @@ const ProfilePage = ({user}) => {
   const { data: currentUserFromHook } = useCurrentUser();
 
   const currentUser = (user || currentUserFromHook)
-  console.log("currentUser: ", currentUser);
   if (!currentUser.loggedIn) {
     return <p>Not logged in.</p>;
   }

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -26,20 +26,26 @@ const ProfilePage = () => {
         </Col>
         <Col md>
           <h2>{fullName}</h2>
-          <p className="lead text-muted">{email}</p>
+          {/* This is supposed to be pronouns */}
+          {/* <p className="lead text-muted">{currentUser.root.user.emailVerified ? "Yes": ""}</p> */}
+          {/* <p className="lead text-muted">{email}</p> */}
           <RoleBadge role={"ROLE_USER"} currentUser={currentUser} />
           <RoleBadge role={"ROLE_MEMBER"} currentUser={currentUser} />
           <RoleBadge role={"ROLE_ADMIN"} currentUser={currentUser} />
-          <RoleBadge role={"ROLE_DRIVER"} currentUser={currentUser} />
-          <RoleBadge role={"ROLE_RIDER"} currentUser={currentUser} />
         </Col>
       </Row>
       <Row className="text-left">
         <div>
-            <h4>Email Verified?</h4>
-            <p>{currentUser.root.user.emailVerified ? "Yes" : "No"}</p>
-            <h4>Email</h4>
+            <h4>Email:</h4>
             <p>{email}</p>
+            <h4>Role:</h4>
+            <p>
+            {currentUser.root.user.rider
+              ? "Rider"
+              : currentUser.root.user.driver
+              ? "Driver"
+              : "N/A"}
+            </p>
         </div>
       </Row>
     </BasicLayout>

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -12,7 +12,7 @@ const ProfilePage = () => {
   }
 
   const { email, pictureUrl, fullName } = currentUser.root.user;
-//   const emailVerified = currentUser.root.user.emailVerified;
+
 
   return (
     <BasicLayout>
@@ -26,26 +26,32 @@ const ProfilePage = () => {
         </Col>
         <Col md>
           <h2>{fullName}</h2>
-          {/* This is supposed to be pronouns */}
-          {/* <p className="lead text-muted">{currentUser.root.user.emailVerified ? "Yes": ""}</p> */}
-          {/* <p className="lead text-muted">{email}</p> */}
+          {/* FUTURE: Pronouns go here, if pronoun field is null, add endpoint for user to modify*/}
           <RoleBadge role={"ROLE_USER"} currentUser={currentUser} />
           <RoleBadge role={"ROLE_MEMBER"} currentUser={currentUser} />
           <RoleBadge role={"ROLE_ADMIN"} currentUser={currentUser} />
+          <p style={{ color: 'rgba(128, 128, 128, 0.5)' }}>
+          Please contact an admin if any of these parameters are incorrect
+          </p>
         </Col>
       </Row>
       <Row className="text-left">
         <div>
             <h4>Email:</h4>
             <p>{email}</p>
-            <h4>Role:</h4>
+            <h4>Admin Status:</h4>
+            <p>
+              {currentUser.root.user.admin ? "Active Admin" : "Not an Admin"}
+            </p>
+            <h4>Rider Status:</h4>
             <p>
             {currentUser.root.user.rider
-              ? "Rider"
-              : currentUser.root.user.driver
-              ? "Driver"
-              : "N/A"}
+              ? "Active Rider" : "Not a Rider"}
             </p>
+            <h4>Driver Status:</h4>
+            <p>{currentUser.root.user.driver ? "Active Driver" : "Not a Driver" }</p>
+
+            {/*FUTURE: Include Wheelchair status in this page. Add toggle functionality*/}
         </div>
       </Row>
     </BasicLayout>

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -36,8 +36,6 @@ const ProfilePage = () => {
       </Row>
       <Row className="text-left">
         <div>
-            <h4>Pronouns:</h4>
-            <p>{currentUser.root.user.pronouns}</p>
             <h4>Email Verified?</h4>
             <p>{currentUser.root.user.emailVerified ? "Yes" : "No"}</p>
             <h4>Email</h4>

--- a/frontend/src/stories/pages/ProfilePage.stories.js
+++ b/frontend/src/stories/pages/ProfilePage.stories.js
@@ -1,12 +1,14 @@
+
 import React from 'react';
 
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
 import ProfilePage from "main/pages/ProfilePage";
 
 export default {
     title: 'pages/ProfilePage',
-    component: ProfilePage
+    component: ProfilePage,
 };
 
-const Template = () => <ProfilePage />;
+const Template = () => <ProfilePage user = {currentUserFixtures.adminUser} />;
 
 export const Default = Template.bind({});

--- a/frontend/src/stories/pages/ProfilePage.stories.js
+++ b/frontend/src/stories/pages/ProfilePage.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import HomePage from "main/pages/ProfilePage";
+import ProfilePage from "main/pages/ProfilePage";
 
 export default {
     title: 'pages/ProfilePage',

--- a/frontend/src/stories/pages/ProfilePage.stories.js
+++ b/frontend/src/stories/pages/ProfilePage.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import HomePage from "main/pages/ProfilePage";
+
+export default {
+    title: 'pages/ProfilePage',
+    component: ProfilePage
+};
+
+const Template = () => <ProfilePage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/tests/pages/ProfilePage.test.js
+++ b/frontend/src/tests/pages/ProfilePage.test.js
@@ -49,7 +49,9 @@ describe("ProfilePage tests", () => {
         expect(getByTestId("role-badge-admin")).toBeInTheDocument();
         expect(getByTestId("role-badge-member")).toBeInTheDocument();
         expect(getByText("phtcon@ucsb.edu")).toBeInTheDocument();
-        expect(getByText("N/A")).toBeInTheDocument();
+        expect(getByText("Active Admin")).toBeInTheDocument();
+        expect(getByText("Not a Rider")).toBeInTheDocument();
+        expect(getByText("Not a Driver")).toBeInTheDocument();
     });
     test("renders correctly for Rider user", async () => {
 
@@ -70,7 +72,9 @@ describe("ProfilePage tests", () => {
         // expect(getByTestId("role-badge-admin")).toBeInTheDocument();
         // expect(getByTestId("role-badge-member")).toBeInTheDocument();
         expect(getByText("pconrad.cis@gmail.com")).toBeInTheDocument();
-        expect(getByText("Rider")).toBeInTheDocument();
+        expect(getByText("Not an Admin")).toBeInTheDocument();
+        expect(getByText("Active Rider")).toBeInTheDocument();
+        expect(getByText("Not a Driver")).toBeInTheDocument();
     });
     test("renders correctly for Driver user", async () => {
 
@@ -91,7 +95,9 @@ describe("ProfilePage tests", () => {
         // expect(getByTestId("role-badge-admin")).toBeInTheDocument();
         // expect(getByTestId("role-badge-member")).toBeInTheDocument();
         expect(getByText("pconrad.cis@gmail.com")).toBeInTheDocument();
-        expect(getByText("Driver")).toBeInTheDocument();
+        expect(getByText("Not an Admin")).toBeInTheDocument();
+        expect(getByText("Not a Rider")).toBeInTheDocument();
+        expect(getByText("Active Driver")).toBeInTheDocument();
     });
 });
 

--- a/frontend/src/tests/pages/ProfilePage.test.js
+++ b/frontend/src/tests/pages/ProfilePage.test.js
@@ -66,7 +66,7 @@ describe("ProfilePage tests", () => {
         );
 
         await waitFor( () => expect(getByText("Phillip Conrad")).toBeInTheDocument() );
-        // expect(getByTestId("role-badge-user")).toBeInTheDocument();
+        expect(getByTestId("role-badge-user")).toBeInTheDocument();
         // expect(getByTestId("role-badge-admin")).toBeInTheDocument();
         // expect(getByTestId("role-badge-member")).toBeInTheDocument();
         expect(getByText("pconrad.cis@gmail.com")).toBeInTheDocument();

--- a/frontend/src/tests/pages/ProfilePage.test.js
+++ b/frontend/src/tests/pages/ProfilePage.test.js
@@ -45,10 +45,53 @@ describe("ProfilePage tests", () => {
         );
 
         await waitFor( () => expect(getByText("Phill Conrad")).toBeInTheDocument() );
-        expect(getByText("phtcon@ucsb.edu")).toBeInTheDocument();
         expect(getByTestId("role-badge-user")).toBeInTheDocument();
         expect(getByTestId("role-badge-admin")).toBeInTheDocument();
         expect(getByTestId("role-badge-member")).toBeInTheDocument();
+        expect(getByText("phtcon@ucsb.edu")).toBeInTheDocument();
+        expect(getByText("N/A")).toBeInTheDocument();
+    });
+    test("renders correctly for Rider user", async () => {
+
+        const axiosMock =new AxiosMockAdapter(axios);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly2);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+        const { getByText, getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ProfilePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor( () => expect(getByText("Phillip Conrad")).toBeInTheDocument() );
+        // expect(getByTestId("role-badge-user")).toBeInTheDocument();
+        // expect(getByTestId("role-badge-admin")).toBeInTheDocument();
+        // expect(getByTestId("role-badge-member")).toBeInTheDocument();
+        expect(getByText("pconrad.cis@gmail.com")).toBeInTheDocument();
+        expect(getByText("Rider")).toBeInTheDocument();
+    });
+    test("renders correctly for Driver user", async () => {
+
+        const axiosMock =new AxiosMockAdapter(axios);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+        const { getByText, getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ProfilePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor( () => expect(getByText("Phillip Conrad")).toBeInTheDocument() );
+        expect(getByTestId("role-badge-user")).toBeInTheDocument();
+        // expect(getByTestId("role-badge-admin")).toBeInTheDocument();
+        // expect(getByTestId("role-badge-member")).toBeInTheDocument();
+        expect(getByText("pconrad.cis@gmail.com")).toBeInTheDocument();
+        expect(getByText("Driver")).toBeInTheDocument();
     });
 });
 

--- a/frontend/src/tests/pages/ProfilePage.test.js
+++ b/frontend/src/tests/pages/ProfilePage.test.js
@@ -48,6 +48,11 @@ describe("ProfilePage tests", () => {
         expect(getByTestId("role-badge-user")).toBeInTheDocument();
         expect(getByTestId("role-badge-admin")).toBeInTheDocument();
         expect(getByTestId("role-badge-member")).toBeInTheDocument();
+        const contactMessage = getByText(
+            "Please contact an admin if any of these parameters are incorrect"
+          );
+      
+        expect(contactMessage).toHaveStyle("color: rgba(128, 128, 128, 0.5)");
         expect(getByText("phtcon@ucsb.edu")).toBeInTheDocument();
         expect(getByText("Active Admin")).toBeInTheDocument();
         expect(getByText("Not a Rider")).toBeInTheDocument();


### PR DESCRIPTION
Revamped the profile page frontend to include driver, admin, and rider status. Additionally, I created 2 more userFixtures to test the functionality.
NOTE: There are comments in the code noting where I envisioned wheelchair status and pronoun features to be presented. These features are 2 integral parts of the profile page contingent on the PR's for pronouns and wheelchair endpoints.
Here is a photo (running on springboot): 
<img width="1295" alt="Screen Shot 2023-06-06 at 3 19 12 PM" src="https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-1/assets/73577225/4ba02699-7938-4d03-a69f-3f385c102b15">

Storybook link:
http://localhost:6006/?path=/docs/pages-profilepage--default

Edit by P. Conrad: Or maybe this?

* Before:  (no storybook)
* After: https://ucsb-cs156-s23.github.io/proj-gauchoride-s23-5pm-1/prs/37/storybook/?path=/docs/pages-profilepage--default