### PR TITLE
Pc customize mock user

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/CurrentUserService.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/CurrentUserService.java
@@ -16,4 +16,11 @@ public abstract class CurrentUserService {
     return getUser() != null;
   }
 
+  /**
+   * This should only be called in test code, never in production code!
+   * 
+   * It resets the current user to a known state for tests, in case
+   * a previous test has changed it in some way.
+   */
+  public abstract void resetCurrentUser();
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/CurrentUserServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/CurrentUserServiceImpl.java
@@ -7,6 +7,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import javax.management.RuntimeErrorException;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -97,5 +99,9 @@ public class CurrentUserServiceImpl extends CurrentUserService {
 
   public Collection<? extends GrantedAuthority> getRoles() {
    return grantedAuthoritiesService.getGrantedAuthorities();
+  }
+
+  public void resetCurrentUser() {
+    throw new RuntimeException("resetCurrentUser should not be called in production code!");
   }
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/testconfig/MockCurrentUserServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/testconfig/MockCurrentUserServiceImpl.java
@@ -26,6 +26,8 @@ import edu.ucsb.cs156.gauchoride.services.CurrentUserServiceImpl;
 @Service("currentUser")
 public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
 
+  private User mockUser;
+
   public User getMockUser(SecurityContext securityContext, Authentication authentication) {
     Object principal = authentication.getPrincipal();
 
@@ -84,7 +86,7 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
     return u;
   }
 
-  public User getUser() {
+  private User initUser() {
     SecurityContext securityContext = SecurityContextHolder.getContext();
     Authentication authentication = securityContext.getAuthentication();
 
@@ -93,6 +95,13 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
     }
 
     return null;
+  }
+
+  public User getUser() {
+    if (mockUser == null) {
+      mockUser = initUser();
+    }
+    return mockUser;
   }
 
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/testconfig/MockCurrentUserServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/testconfig/MockCurrentUserServiceImpl.java
@@ -104,4 +104,8 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
     return mockUser;
   }
 
+  public void resetCurrentUser() {
+    mockUser = initUser();
+  }
+  
 }


### PR DESCRIPTION
In this PR, we add a new method to the CurrentUser interface, and two implementations: one for production, the other for tests.

The new method is called: `resetCurrentUser` and it allows, in a test, the coder to reset the CurrentUser to its default state.

In regular production mode, calling this method will throw a RuntimeException.

We also change the implementation of CurrentUserService that is used in tests so that the User object returned is consistent and persistent, so that it can be modified to simulate whatever kind of user is needed in the test.

For example, you may have a test where you need the CurrentUser to be a wheelchair user, and another where you need the CurrentUser to *not* be a wheelchair user.

You can do this:

```java
                   // arrange
                    User currentUser = currentUserService.getCurrentUser().getUser();
                    currentUser.setWheelchair(true);
```

or this:

```java
                   // arrange
                    User currentUser = currentUserService.getCurrentUser().getUser();
                    currentUser.setWheelchair(false);
```

And afterwards, if you have changed the state of the CurrentUser, you can do this at the end of the test to be sure that your changes to the CurrentUser do not leak into other tests:

```java
   currentUserService.resetCurrentUser();
```